### PR TITLE
Fixed 'unnamed' routes

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -20,7 +20,7 @@ module Grape
           route_path = route.route_path
           route_match = route_path.split(/^.*?#{route.route_prefix.to_s}/).last
           next unless route_match
-          route_match = route_match.match('\/([\w|-]*?)[\.\/\(]') || route_match.match('\/([\w|-]*)')
+          route_match = route_match.match('\/([\w|-]*?)[\.\/\(]') || route_match.match('\/([a-z]+)')
           next unless route_match
           resource = route_match.captures.first
           next if resource.empty?


### PR DESCRIPTION
```get :archived do``` works ok but ```get do``` not
should fix regex to target that?

```
      resource :orders do
        desc "Return list of all orders", { object_fields: API::V1::Entities::Order.documentation }
        get do
          present Order.today, with: API::V1::Entities::Order
        end

        desc "Return archived (closed) orders for specified account"
        params do
          requires :identifier, type: String, desc: "Account identifier"
        end
        get :archived do
          account = Account.find_by(identifier: params[:identifier])
          raise "AccountNotFound" unless account

          present account.orders.archived, with: API::V1::Entities::Order
        end
     end
```