### PR TITLE
Fixed the bug where 'is_array' in the return entity is ignored.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,11 +12,11 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 397
+  Max: 401
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:
-  Max: 93
+  Max: 94
 
 # Offense count: 195
 # Configuration parameters: AllowURI, URISchemes.
@@ -26,11 +26,11 @@ Metrics/LineLength:
 # Offense count: 13
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 359
+  Max: 362
 
 # Offense count: 4
 Metrics/PerceivedComplexity:
-  Max: 96
+  Max: 97
 
 # Offense count: 7
 Style/ClassVars:

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -454,7 +454,7 @@ module Grape
                       nickname: route.route_nickname || (route.route_method + route.route_path.gsub(/[\/:\(\)\.]/, '-')),
                       method: route.route_method,
                       parameters: @@documentation_class.parse_header_params(route.route_headers) + @@documentation_class.parse_params(route.route_params, route.route_path, route.route_method),
-                      type: 'void'
+                      type: route.route_is_array ? 'array' : 'void'
                     }
                     operation[:authorizations] = route.route_authorizations unless route.route_authorizations.nil? || route.route_authorizations.empty?
                     if operation[:parameters].any? { | param | param[:type] == 'File' }
@@ -464,7 +464,11 @@ module Grape
 
                     if route.route_entity
                       type = @@documentation_class.parse_entity_name(route.route_entity)
-                      operation.merge!('type' => type)
+                      if route.route_is_array
+                        operation.merge!(items: { '$ref' => type })
+                      else
+                        operation.merge!(type: type)
+                      end
                     end
 
                     operation[:nickname] = route.route_nickname if route.route_nickname


### PR DESCRIPTION
When the entity is marked with 'is_array', swagger will show it as array of entities. Example:

      desc 'Get all teams', {
                            is_array: true,
                            entity: API::Entities::TeamRecord
      }
      get '/' do
        teams = TeamsCatalog.teams.limit(100).to_a
        present teams, include_children: true
      end
