### PR TITLE
use grape `detail` for swagger `notes`

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -454,7 +454,7 @@ module Grape
 
                 ops.each do |path, op_routes|
                   operations = op_routes.map do |route|
-                    notes       = @@documentation_class.as_markdown(route.route_notes)
+                    notes       = @@documentation_class.as_markdown(route.route_detail)
 
                     http_codes  = @@documentation_class.parse_http_codes(route.route_http_codes, models)
 


### PR DESCRIPTION
ref #212 

Read grape's `detail` into swagger's `notes`.

For example, my API endpoint:
```ruby
desc "Returns your public timeline." do
  detail 'more details'
end
get :public_timeline do
  Status.limit(20)
end
```

will generate such swagger doc:
```json
"operations": [
  {
    "notes": "more details",
    "summary": "Returns your public timeline.",
    "nickname": .....
......
}
```
