### PR TITLE
add the the failing spec for the issue which related to API with :path versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Next Release
+
 * [#214](https://github.com/tim-vandecasteele/grape-swagger/pull/214): Allow anything that responds to `call` to be used in `:hidden` - [@zbelzer](https://github.com/zbelzer).
 * [#211](https://github.com/tim-vandecasteele/grape-swagger/pull/211): Fixed the dependency, just `require 'grape'` - [@u2](https://github.com/u2).
 * [#210](https://github.com/tim-vandecasteele/grape-swagger/pull/210): Fixed the range `:values` option, now exposed as `enum` parameters - [@u2](https://github.com/u2).
@@ -6,6 +7,11 @@
 * [#196](https://github.com/tim-vandecasteele/grape-swagger/pull/196): If `:type` is omitted, see if it's available in `:using` - [@jhollinger](https://github.com/jhollinger).
 * [#200](https://github.com/tim-vandecasteele/grape-swagger/pull/200): Treat `type: Symbol` as string form parameter - [@ypresto](https://github.com/ypresto).
 * [#207](https://github.com/tim-vandecasteele/grape-swagger/pull/207): Support grape `mutually_exclusive` - [@mintuhouse](https://github.com/mintuhouse).
+
+#### Fixes
+
+* [#216](https://github.com/tim-vandecasteele/grape-swagger/pull/216): Fix API route paths matching. This prevents the disappearance of the documentation for root endpoints in case you are using `grape ~> 0.10.0`, specific `format` and `:path` versioning. Fixes [#192](https://github.com/tim-vandecasteele/grape-swagger/issues/192), [#189](https://github.com/tim-vandecasteele/grape-swagger/issues/189). - [@dm1try](https://github.com/dm1try) [@minch](https://github.com/minch)
+
 * Your contribution here.
 
 ### 0.9.0 (December 19, 2014)

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -21,7 +21,7 @@ module Grape
           route_path = route.route_path
           route_match = route_path.split(/^.*?#{route.route_prefix.to_s}/).last
           next unless route_match
-          route_match = route_match.match('\/([\w|-]*?)[\.\/\(]') || route_match.match('\/([\w|-]*)')
+          route_match = route_match.match('\/([\w|-]*?)[\.\/\(]') || route_match.match('\/([\w|-]*)$')
           next unless route_match
           resource = route_match.captures.first
           next if resource.empty?

--- a/spec/api_with_path_versioning_spec.rb
+++ b/spec/api_with_path_versioning_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'Api with "path" versioning' do
+  let(:json_body) { JSON.parse(last_response.body) }
+
+  before :all do
+    class ApiWithPathVersioning < Grape::API
+      format :json
+      version 'v1', using: :path
+
+      namespace :resources do
+        get
+      end
+
+      add_swagger_documentation api_version: 'v1'
+    end
+  end
+
+  def app
+    ApiWithPathVersioning
+  end
+
+  it 'retrieves swagger-documentation on /swagger_doc that contains :resources api path' do
+    get '/v1/swagger_doc'
+
+    expect(json_body['apis']).to eq(
+      [
+        { 'path' => '/resources.{format}', 'description' => 'Operations about resources' },
+        { 'path' => '/swagger_doc.{format}', 'description' => 'Operations about swagger_docs' }
+      ]
+    )
+  end
+end


### PR DESCRIPTION
so when you specify api "format" and use "path" versioning then "root" endpoints disappear from swagger docs
related to grape >= 0.10.0

Run spec:
```bash
GRAPE_VERSION="~>0.10" bundle update grape
GRAPE_VERSION="~>0.10" bundle exec rspec spec/api_with_path_versioning_spec.rb
```
