### PR TITLE
Support for multiple entities

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,7 +7,7 @@
 
 # Offense count: 8
 Metrics/AbcSize:
-  Max: 331
+  Max: 334
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* [#](https://github.com/tim-vandecasteele/grape-swagger/pull/): Support Array of entities for proper rendering of grape-entity input dependencies - [@swistaczek](https://github.com/swistaczek).
+* [#217](https://github.com/tim-vandecasteele/grape-swagger/pull/217): Support Array of entities for proper rendering of grape-entity input dependencies - [@swistaczek](https://github.com/swistaczek).
 * [#214](https://github.com/tim-vandecasteele/grape-swagger/pull/214): Allow anything that responds to `call` to be used in `:hidden` - [@zbelzer](https://github.com/zbelzer).
 * [#196](https://github.com/tim-vandecasteele/grape-swagger/pull/196): If `:type` is omitted, see if it's available in `:using` - [@jhollinger](https://github.com/jhollinger).
 * [#200](https://github.com/tim-vandecasteele/grape-swagger/pull/200): Treat `type: Symbol` as string form parameter - [@ypresto](https://github.com/ypresto).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#](https://github.com/tim-vandecasteele/grape-swagger/pull/): Support Array of entities for proper rendering of grape-entity input dependencies - [@swistaczek](https://github.com/swistaczek).
 * [#214](https://github.com/tim-vandecasteele/grape-swagger/pull/214): Allow anything that responds to `call` to be used in `:hidden` - [@zbelzer](https://github.com/zbelzer).
 * [#196](https://github.com/tim-vandecasteele/grape-swagger/pull/196): If `:type` is omitted, see if it's available in `:using` - [@jhollinger](https://github.com/jhollinger).
 * [#200](https://github.com/tim-vandecasteele/grape-swagger/pull/200): Treat `type: Symbol` as string form parameter - [@ypresto](https://github.com/ypresto).

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -464,7 +464,7 @@ module Grape
 
                     models |= @@models if @@models.present?
 
-                    models |= [route.route_entity] if route.route_entity.present?
+                    models |= Array(route.route_entity) if route.route_entity.present?
 
                     models = @@documentation_class.models_with_included_presenters(models.flatten.compact)
 
@@ -483,7 +483,7 @@ module Grape
                     operation.merge!(responseMessages: http_codes) unless http_codes.empty?
 
                     if route.route_entity
-                      type = @@documentation_class.parse_entity_name(route.route_entity)
+                      type = @@documentation_class.parse_entity_name(Array(route.route_entity).first)
                       operation.merge!('type' => type)
                     end
 

--- a/spec/api_models_spec.rb
+++ b/spec/api_models_spec.rb
@@ -80,10 +80,13 @@ describe 'API Models' do
     end
 
     class QueryInput < Grape::Entity
-      expose :elements, using: Entities::QueryInputElement,
-        documentation: { type: 'QueryInputElement',
-          desc: 'Set of configuration',
-          param_type: 'body', is_array: true, required: true }
+      expose :elements, using: Entities::QueryInputElement, documentation: {
+        type: 'QueryInputElement',
+        desc: 'Set of configuration',
+        param_type: 'body',
+        is_array: true,
+        required: true
+      }
     end
 
     class QueryResult < Grape::Entity
@@ -139,8 +142,8 @@ describe 'API Models' do
       end
 
       desc 'This tests diffrent entity for input and diffrent for output',
-        entity: [ Entities::QueryResult, Entities::QueryInput ],
-        params: Entities::QueryInput.documentation
+           entity: [Entities::QueryResult, Entities::QueryInput],
+           params: Entities::QueryInput.documentation
       get '/multiple_entities' do
         result = OpenStruct.new(elements_size: params[:elements].size)
         present result, with: Entities::QueryResult

--- a/spec/api_models_spec.rb
+++ b/spec/api_models_spec.rb
@@ -71,6 +71,26 @@ describe 'API Models' do
     end
   end
 
+  module Entities
+    class QueryInputElement < Grape::Entity
+      expose :key, documentation: {
+        type: String, desc: 'Name of parameter', required: true }
+      expose :value, documentation: {
+        type: String, desc: 'Value of parameter', required: true }
+    end
+
+    class QueryInput < Grape::Entity
+      expose :elements, using: Entities::QueryInputElement,
+        documentation: { type: 'QueryInputElement',
+          desc: 'Set of configuration',
+          param_type: 'body', is_array: true, required: true }
+    end
+
+    class QueryResult < Grape::Entity
+      expose :elements_size, documentation: { type: Integer, desc: 'Return input elements size' }
+    end
+  end
+
   def app
     Class.new(Grape::API) do
       format :json
@@ -118,6 +138,14 @@ describe 'API Models' do
         present first_level, with: Entities::FirstLevel
       end
 
+      desc 'This tests diffrent entity for input and diffrent for output',
+        entity: [ Entities::QueryResult, Entities::QueryInput ],
+        params: Entities::QueryInput.documentation
+      get '/multiple_entities' do
+        result = OpenStruct.new(elements_size: params[:elements].size)
+        present result, with: Entities::QueryResult
+      end
+
       add_swagger_documentation
     end
   end
@@ -145,6 +173,7 @@ describe 'API Models' do
         { 'path' => '/enum_description_in_entity.{format}', 'description' => 'Operations about enum_description_in_entities' },
         { 'path' => '/aliasedthing.{format}', 'description' => 'Operations about aliasedthings' },
         { 'path' => '/nesting.{format}', 'description' => 'Operations about nestings' },
+        { 'path' => '/multiple_entities.{format}', 'description' => 'Operations about multiple_entities' },
         { 'path' => '/swagger_doc.{format}', 'description' => 'Operations about swagger_docs' }
       ]
     end
@@ -250,5 +279,12 @@ describe 'API Models' do
     result = JSON.parse(last_response.body)
 
     expect(result['models']).to include('FirstLevel', 'SecondLevel', 'ThirdLevel', 'FourthLevel')
+  end
+
+  it 'includes all entities while using multiple entities' do
+    get '/swagger_doc/multiple_entities'
+    result = JSON.parse(last_response.body)
+
+    expect(result['models']).to include('QueryInput', 'QueryInputElement', 'QueryResult')
   end
 end


### PR DESCRIPTION
Hey @dblock,
I have created this pull request to add support for multiple entities in grape-swagger. One of usage case is when I would like to specify some entity as required for input and I would like to return other entity in response for that query. I have described following case in specs.

Thanks in advantage for any clues if there is something to fix.