### PR TITLE
Converting integer :values range to a minimum/maximum numeric Range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 
+* [#259](https://github.com/tim-vandecasteele/grape-swagger/pull/259): Fixed range values and converting integer :values range to a minimum/maximum numeric Range - [@u2](https://github.com/u2).
 * [#252](https://github.com/tim-vandecasteele/grape-swagger/pull/252): Allow docs to mounted in separate class than target - [@iangreenleaf](https://github.com/iangreenleaf).
 * [#251](https://github.com/tim-vandecasteele/grape-swagger/pull/251): Fixed model id equal to model name when root existing in entities - [@aitortomas](https://github.com/aitortomas).
 * [#232](https://github.com/tim-vandecasteele/grape-swagger/pull/232): Fixed missing raw array params - [@u2](https://github.com/u2).

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -164,14 +164,24 @@ module Grape
         modified_params
       end
 
-      def parse_enum_values(values)
-        if values.is_a?(Range) && [Integer, String].any? { |klass| values.first.is_a?(klass) }
-          values.to_a
-        elsif values.is_a?(Proc)
-          values.call
+      def parse_enum_or_range_values(values)
+        case values
+        when Range
+          parse_range_values(values) if values.first.is_a?(Integer)
+        when Proc
+          values_result = values.call
+          if values_result.is_a?(Range) && values_result.first.is_a?(Integer)
+            parse_range_values(values_result)
+          else
+            { enum: values_result }
+          end
         else
-          values
+          { enum: values } if values
         end
+      end
+
+      def parse_range_values(values)
+        { minimum: values.first, maximum: values.last }
       end
 
       def create_documentation_class

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -47,13 +47,13 @@ module GrapeSwagger
           value = additional_documentation.merge(value)
         end
 
-        description   = value.is_a?(Hash) ? value[:desc] || value[:description] : ''
-        required      = value.is_a?(Hash) ? !!value[:required] : false
-        default_value = value.is_a?(Hash) ? value[:default] : nil
-        example       = value.is_a?(Hash) ? value[:example] : nil
-        is_array      = value.is_a?(Hash) ? (value[:is_array] || false) : false
-        values        = value.is_a?(Hash) ? value[:values] : nil
-        enum_values   = parse_enum_values(values)
+        description          = value.is_a?(Hash) ? value[:desc] || value[:description] : ''
+        required             = value.is_a?(Hash) ? !!value[:required] : false
+        default_value        = value.is_a?(Hash) ? value[:default] : nil
+        example              = value.is_a?(Hash) ? value[:example] : nil
+        is_array             = value.is_a?(Hash) ? (value[:is_array] || false) : false
+        values               = value.is_a?(Hash) ? value[:values] : nil
+        enum_or_range_values = parse_enum_or_range_values(values)
 
         if value.is_a?(Hash) && value.key?(:documentation) && value[:documentation].key?(:param_type)
           param_type  = value[:documentation][:param_type]
@@ -86,14 +86,16 @@ module GrapeSwagger
           allowMultiple: is_array
         }
 
-        parsed_params.merge!(format: 'int32') if data_type == 'integer'
-        parsed_params.merge!(format: 'int64') if data_type == 'long'
-        parsed_params.merge!(items: items) if items.present?
-        parsed_params.merge!(defaultValue: example) if example
+        parsed_params[:format] = 'int32' if data_type == 'integer'
+        parsed_params[:format] = 'int64' if data_type == 'long'
+        parsed_params[:items]  = items   if items.present?
+
+        parsed_params[:defaultValue] = example if example
         if default_value && example.blank?
-          parsed_params.merge!(defaultValue: default_value)
+          parsed_params[:defaultValue] = default_value
         end
-        parsed_params.merge!(enum: enum_values) if enum_values
+
+        parsed_params.merge!(enum_or_range_values) if enum_or_range_values
         parsed_params
       end
     end

--- a/spec/param_values_spec.rb
+++ b/spec/param_values_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'grape_version'
 
-describe 'Convert values to enum' do
+describe 'Convert values to enum or Range' do
   def app
     Class.new(Grape::API) do
       format :json
@@ -64,17 +64,17 @@ describe 'Convert values to enum' do
   context 'Range values' do
     subject(:range_letter) { first_parameter_info('range_letter') }
 
-    it 'has letter range values as array in enum' do
+    it 'has letter range values' do
       expect(range_letter).to eq [
-        { 'paramType' => 'form', 'name' => 'letter', 'description' => nil, 'type' => 'string', 'required' => true, 'allowMultiple' => false, 'enum' => ('a'..'z').to_a }
+        { 'paramType' => 'form', 'name' => 'letter', 'description' => nil, 'type' => 'string', 'required' => true, 'allowMultiple' => false }
       ]
     end
 
     subject(:range_integer) { first_parameter_info('range_integer') }
 
-    it 'has integer range values as array in enum' do
+    it 'has integer range values' do
       expect(range_integer).to eq [
-        { 'paramType' => 'form', 'name' => 'integer', 'description' => nil, 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32', 'enum' => (-5..5).to_a }
+        { 'paramType' => 'form', 'name' => 'integer', 'description' => nil, 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32', 'minimum' => -5, 'maximum' => 5 }
       ]
     end
   end
@@ -121,9 +121,9 @@ describe 'Convert values to enum for float range and not arrays inside a proc', 
   context 'Range values' do
     subject(:range_float) { first_parameter_info('range_float') }
 
-    it 'has float range values as string in enum' do
+    it 'has float range values as string' do
       expect(range_float).to eq [
-        { 'paramType' => 'form', 'name' => 'float', 'description' => nil, 'type' => 'float', 'required' => true, 'allowMultiple' => false, 'enum' => '-5.0..5.0' }
+        { 'paramType' => 'form', 'name' => 'float', 'description' => nil, 'type' => 'float', 'required' => true, 'allowMultiple' => false }
       ]
     end
   end


### PR DESCRIPTION
https://github.com/swagger-api/swagger-core/wiki/Datatypes

>Some model properties may be restricted to a fixed set of values. To support this use case, the property field can have an optional enum property, which supports a list of allowable values, or a minimum/maximum numeric Range. For example:
```
"Pet": {
  "id": "Pet",
  "description": "A pet is a person's best friend",
  "required": [
    "name",
    "id"
  ],
  "properties": {
    "status": {
      "type": "string",
      "description": "pet status in the store",
      "enum": [
        "available",
        "pending",
        "sold"
      ]
    },
    "happiness": {
      "type": "integer",
      "format": "int32",
      "description": "how happy the Pet appears to be, where 10 is 'extremely happy'",
      "minimum": 1,
      "maximum": 10
    },
  ...
```

So the `Ineteger` `Range` should be converted to `minimum/maximum numeric Range`, right?