### PR TITLE
Fixed bug: Would hide docs for certain endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 
+* [#260](https://github.com/tim-vandecasteele/grape-swagger/pull/260): Fixed endpoints that would wrongly be hidden if `hide_documentation_path` is set - [@QuickPay](https://github.com/QuickPay).
 * [#259](https://github.com/tim-vandecasteele/grape-swagger/pull/259): Fixed range values and converting integer :values range to a minimum/maximum numeric Range - [@u2](https://github.com/u2).
 * [#252](https://github.com/tim-vandecasteele/grape-swagger/pull/252): Allow docs to mounted in separate class than target - [@iangreenleaf](https://github.com/iangreenleaf).
 * [#251](https://github.com/tim-vandecasteele/grape-swagger/pull/251): Fixed model id equal to model name when root existing in entities - [@aitortomas](https://github.com/aitortomas).

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -31,7 +31,7 @@ module Grape
           next if resource.empty?
           resource.downcase!
           @target_class.combined_routes[resource] ||= []
-          next if documentation_class.hide_documentation_path && route.route_path.include?(documentation_class.mount_path)
+          next if documentation_class.hide_documentation_path && route.route_path.match(/#{documentation_class.mount_path}(\W|$)/)
           @target_class.combined_routes[resource] << route
         end
 


### PR DESCRIPTION
When docs are hidden with `hide_documentation_path` and an endpoint's
path begin with the same string as the docs mount path, the endpoint is
hidden.

Example: Swagger docs are mounted en `/doc`, then endpoint `/documents` are hidden if `hide_documentation_path` is `true`.

This fixes it