### PR TITLE
Fixes paths that starts with mount path followed by dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### Fixes
 
-* [#260](https://github.com/tim-vandecasteele/grape-swagger/pull/260): Fixed endpoints that would wrongly be hidden if `hide_documentation_path` is set - [@QuickPay](https://github.com/QuickPay).
+* [#260](https://github.com/tim-vandecasteele/grape-swagger/pull/260), [#261](https://github.com/tim-vandecasteele/grape-swagger/pull/261): Fixed endpoints that would wrongly be hidden if `hide_documentation_path` is set - [@QuickPay](https://github.com/QuickPay).
 * [#259](https://github.com/tim-vandecasteele/grape-swagger/pull/259): Fixed range values and converting integer :values range to a minimum/maximum numeric Range - [@u2](https://github.com/u2).
 * [#252](https://github.com/tim-vandecasteele/grape-swagger/pull/252): Allow docs to mounted in separate class than target - [@iangreenleaf](https://github.com/iangreenleaf).
 * [#251](https://github.com/tim-vandecasteele/grape-swagger/pull/251): Fixed model id equal to model name when root existing in entities - [@aitortomas](https://github.com/aitortomas).

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -31,7 +31,7 @@ module Grape
           next if resource.empty?
           resource.downcase!
           @target_class.combined_routes[resource] ||= []
-          next if documentation_class.hide_documentation_path && route.route_path.match(/#{documentation_class.mount_path}(\W|$)/)
+          next if documentation_class.hide_documentation_path && route.route_path.match(/#{documentation_class.mount_path}($|\/|\(\.)/)
           @target_class.combined_routes[resource] << route
         end
 

--- a/spec/api_paths_spec.rb
+++ b/spec/api_paths_spec.rb
@@ -70,6 +70,11 @@ describe 'simple api with partially same path as docs mount and hidden doc path'
       get '/documents' do
         { test: 'something' }
       end
+
+      desc 'This gets the doc types'
+      get '/doc-types' do
+        { test: 'something' }
+      end
     end
 
     class SimpleSamePathApi < Grape::API
@@ -93,7 +98,8 @@ describe 'simple api with partially same path as docs mount and hidden doc path'
       'info' => {},
       'produces' => Grape::ContentTypes::CONTENT_TYPES.values.uniq,
       'apis' => [
-        { 'path' => '/documents.{format}', 'description' => 'Operations about documents' }
+        { 'path' => '/documents.{format}', 'description' => 'Operations about documents' },
+        { 'path' => '/doc-types.{format}', 'description' => 'Operations about doc-types' }
       ]
     )
   end


### PR DESCRIPTION
This is an addition to https://github.com/tim-vandecasteele/grape-swagger/pull/260

There is still a bug in which too many endpoints are hidden when documentation path is hidden.
Changed regex to only disallow

* /mount_path
* /mount_path/*
* /mount_path(.:format)

Specifically, I still had a bug if an endpoint has `"#{mount_point}-"` in it. See the spec.