### PR TITLE
Fixed: Consistent types in header params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 
+* [#264](https://github.com/tim-vandecasteele/grape-swagger/pull/264): Consistent header param types - [@QuickPay](https://github.com/QuickPay).
 * [#260](https://github.com/tim-vandecasteele/grape-swagger/pull/260), [#261](https://github.com/tim-vandecasteele/grape-swagger/pull/261): Fixed endpoints that would wrongly be hidden if `hide_documentation_path` is set - [@QuickPay](https://github.com/QuickPay).
 * [#259](https://github.com/tim-vandecasteele/grape-swagger/pull/259): Fixed range values and converting integer :values range to a minimum/maximum numeric Range - [@u2](https://github.com/u2).
 * [#252](https://github.com/tim-vandecasteele/grape-swagger/pull/252): Allow docs to mounted in separate class than target - [@iangreenleaf](https://github.com/iangreenleaf).

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -127,7 +127,7 @@ module GrapeSwagger
       params ||= []
 
       params.map do |param, value|
-        data_type     = 'String'
+        data_type     = 'string'
         description   = value.is_a?(Hash) ? value[:description] : ''
         required      = value.is_a?(Hash) ? !!value[:required] : false
         default_value = value.is_a?(Hash) ? value[:default] : nil

--- a/spec/grape-swagger_helper_spec.rb
+++ b/spec/grape-swagger_helper_spec.rb
@@ -145,7 +145,7 @@ describe 'helpers' do
         'XAuthToken' => { description: 'A required header.', required: true, default: 'default' }
       }
       expect(subject.parse_header_params(params)).to eq [
-        { paramType: 'header', name: 'XAuthToken', description: 'A required header.', type: 'String', required: true, defaultValue: 'default' }
+        { paramType: 'header', name: 'XAuthToken', description: 'A required header.', type: 'string', required: true, defaultValue: 'default' }
       ]
     end
   end

--- a/spec/param_type_spec.rb
+++ b/spec/param_type_spec.rb
@@ -27,4 +27,26 @@ describe 'Params Types' do
       { 'paramType' => 'query', 'name' => 'input', 'description' => nil, 'type' => 'string', 'required' => true, 'allowMultiple' => false }
     ]
   end
+
+  describe 'header params' do
+    def app
+      Class.new(Grape::API) do
+        format :json
+
+        desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
+        params do
+          requires :input, type: String
+        end
+        post :action do
+        end
+
+        add_swagger_documentation
+      end
+    end
+
+    it 'has consistent types' do
+      types = subject.map { |param| param['type'] }
+      expect(types).to eq(%w(string string))
+    end
+  end
 end

--- a/spec/simple_mounted_api_spec.rb
+++ b/spec/simple_mounted_api_spec.rb
@@ -139,8 +139,8 @@ describe 'a simple mounted api' do
           'nickname' => 'GET-simple_with_headers---format-',
           'method' => 'GET',
           'parameters' => [
-            { 'paramType' => 'header', 'name' => 'XAuthToken', 'description' => 'A required header.', 'type' => 'String', 'required' => true },
-            { 'paramType' => 'header', 'name' => 'XOtherHeader', 'description' => 'An optional header.', 'type' => 'String', 'required' => false }
+            { 'paramType' => 'header', 'name' => 'XAuthToken', 'description' => 'A required header.', 'type' => 'string', 'required' => true },
+            { 'paramType' => 'header', 'name' => 'XOtherHeader', 'description' => 'An optional header.', 'type' => 'string', 'required' => false }
           ],
           'type' => 'void',
           'responseMessages' => [


### PR DESCRIPTION
Header params always have `type: 'String'`, but normal params lowercase the type name so `type: String` becomes `type: 'string'`

This PR makes the header params lowercase too.