### PR TITLE
Removed ruby 1.9.3 and added ruby 2.2.2 to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 sudo: false
 
 rvm:
+  - 2.2.2
   - 2.1.1
   - 2.0.0
-  - 1.9.3
   - rbx-2.2.10
   - jruby-19mode
 


### PR DESCRIPTION
Removed ruby 1.9.3 from travis builds since it is end of life. Added ruby 2.2.2 since its good to be building with a new stable ruby version.
