### PR TITLE
make api doc `name` param recognizable by `declared`

### DIFF
--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -400,14 +400,11 @@ module GrapeSwagger
         output
       end
 
-      desc specific_api_doc.delete(:desc), { params: {
-        'name' => {
-          desc: 'Resource name of mounted API',
-          type: 'string',
-          required: true
-        }
-      }.merge(specific_api_doc.delete(:params) || {}) }.merge(specific_api_doc)
-
+      desc specific_api_doc.delete(:desc), { params:
+        specific_api_doc.delete(:params) || {} }.merge(specific_api_doc)
+      params do
+        requires :name, type: String, desc: 'Resource name of mounted API'
+      end
       get "#{@@mount_path}/:name" do
         header['Access-Control-Allow-Origin']   = '*'
         header['Access-Control-Request-Method'] = '*'

--- a/spec/api_description_spec.rb
+++ b/spec/api_description_spec.rb
@@ -14,7 +14,7 @@ describe 'API Description' do
       expect(routes.first.route_description).to eq 'Swagger compatible API description'
       expect(routes.first.route_params).to eq({})
       expect(routes.last.route_description).to eq 'Swagger compatible API description for specific API'
-      expect(routes.last.route_params).to eq('name' => { desc: 'Resource name of mounted API', type: 'string', required: true })
+      expect(routes.last.route_params).to eq('name' => { desc: 'Resource name of mounted API', type: 'String', required: true })
     end
   end
 
@@ -34,7 +34,7 @@ describe 'API Description' do
       expect(routes.first.route_params).to eq(x: 1)
       expect(routes.first.route_xx).to eq(11)
       expect(routes.last.route_description).to eq 'Second'
-      expect(routes.last.route_params).to eq('name' => { desc: 'Resource name of mounted API', type: 'string', required: true }, y: 42)
+      expect(routes.last.route_params).to eq('name' => { desc: 'Resource name of mounted API', type: 'String', required: true }, y: 42)
       expect(routes.last.route_yy).to eq(4242)
     end
   end


### PR DESCRIPTION
I use a `after_validation` to my api to make sure that all endpoints only get declared params, code sample like:

``` ruby
after_validation do
  @raw_params = params
  @params = declared(params, include_missing: false)
end
```

But this will make swagger doc not available, because this `after_validation` also applies to swagger doc related endpoints, but the required param `:name` cannot be recognized by `declared`.

So i made this PR to make swagger doc endpoints' `:name` param being **declared**.
